### PR TITLE
Visual Studio Code support for ConsoleBox and WebApiBox templates

### DIFF
--- a/.pack.sh
+++ b/.pack.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if ! command -v dotnet-gitversion &> /dev/null; then
+  echo "GitVersion tool is not installed. Installing..."
+  DOTNET_NOLOGO=1
+  dotnet tool install --global GitVersion.Tool --version 5.*
+else
+  echo "GitVersion tool is already installed."
+fi
+
 # Check and install Mono if not present
 if ! command -v mono &> /dev/null; then
   echo "Mono is not installed. Installing..."

--- a/src/Console/.template.config/template.json
+++ b/src/Console/.template.config/template.json
@@ -36,11 +36,9 @@
           ]
         },
         {
-          "condition": "(projectOnly)",
+          "condition": "(!vscode)",
           "exclude": [            
-            "src/ConsoleBox.sln",
-            "README.md",
-            ".gitignore"
+            ".vscode/**"
           ]
         },
         {
@@ -74,6 +72,12 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Set runtime identifier to linux-x64."
+    },
+    "vscode": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Create launch.json for Visual Studio Code."
     },
     "projectOnly": {
       "type": "parameter",

--- a/src/Console/.vscode/launch.json
+++ b/src/Console/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "C#: ConsoleBox Debug",
+            "name": "ConsoleBox (Debug)",
             "type": "dotnet",
             "request": "launch",            
             "projectPath": "${workspaceFolder}/src/ConsoleBox/ConsoleBox.csproj"

--- a/src/Console/.vscode/launch.json
+++ b/src/Console/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "C#: ConsoleBox Debug",
+            "type": "dotnet",
+            "request": "launch",            
+            "projectPath": "${workspaceFolder}/src/ConsoleBox/ConsoleBox.csproj"
+        }
+    ]
+}

--- a/src/WebApi/.vscode/launch.json
+++ b/src/WebApi/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (Web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/WebApiBox/bin/Debug/net8.0/WebApiBox.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/WebApiBox",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+\"(https?://\\S+)\"",
+                "uriFormat": "%s/swagger"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        }
+    ]
+}

--- a/src/WebApi/.vscode/launch.json
+++ b/src/WebApi/.vscode/launch.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (Web)",
+            "name": "WebApiBox (Debug)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",

--- a/src/WebApi/.vscode/tasks.json
+++ b/src/WebApi/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "dotnet",
+			"task": "build",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [],
+			"label": "build"
+		}
+	]
+}


### PR DESCRIPTION
Resolves #57 

- [x] Rename launch names for webapibox and consolebox templates (933a32b)
- [x] Add GitVersion tool installation if not present to pack.sh script (2c06083)
- [x] Add launch and tasks json files for vscode in webapibox template (5db2659)
- [x] Add vscode launch json file for consolebox template (e298e9c)