### PR TITLE
Add development support for Windows with Visual Studio Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,15 +5,20 @@
             "name": "Install JandaBox",
             "type": "node-terminal",            
             "request": "launch",
-            "command": "exit",
-            "preLaunchTask": "Install JandaBox",
+            "command": "dotnet new list JandaBox",
+            "windows": {
+                "preLaunchTask": "install_windows",
+            },
+            "linux": {
+                "preLaunchTask": "install_linux",
+            },
         },
         {
             "name": "Uninstall JandaBox",
             "type": "node-terminal",
             "request": "launch",            
             "command": "exit",
-            "preLaunchTask": "Uninstall JandaBox",
+            "preLaunchTask": "uninstall_jandabox",
         },
         {
             "name": "Try ConsoleBox",
@@ -21,7 +26,12 @@
             "request": "launch",
             "cwd": "/tmp",
             "command": "rm -rf MyConsole;dotnet new consolebox --linux -n MyConsole;cd MyConsole/src;dotnet run --project MyConsole",
-            "preLaunchTask": "Install JandaBox",
+            "windows": {
+                "preLaunchTask": "install_windows",
+            },
+            "linux": {
+                "preLaunchTask": "install_linux",
+            },
         },
         {
             "name": "Try WebApiBox",
@@ -29,7 +39,12 @@
             "request": "launch",
             "cwd": "/tmp",
             "command": "rm -rf MyWebApi;dotnet new webapibox -n MyWebApi;cd MyWebApi/src;dotnet run MyWebApi --project MyWebApi",
-            "preLaunchTask": "Install JandaBox",
+            "windows": {
+                "preLaunchTask": "install_windows",
+            },
+            "linux": {
+                "preLaunchTask": "install_linux",
+            },
         },
         {
             "name": "Try ConsoleBox Project",
@@ -37,7 +52,12 @@
             "request": "launch",
             "cwd": "/tmp",
             "command": "rm -rf MyConsole;dotnet new consoleprj --linux --serilog true -n MyConsole;cd MyConsole;dotnet run",
-            "preLaunchTask": "Install JandaBox",
+            "windows": {
+                "preLaunchTask": "install_windows",
+            },
+            "linux": {
+                "preLaunchTask": "install_linux",
+            },
         },
         {
             "name": "Try WebApiBox Project",
@@ -45,7 +65,12 @@
             "request": "launch",
             "cwd": "/tmp",
             "command": "rm -rf MyWebApi;dotnet new webapiprj -n MyWebApi;cd MyWebApi;dotnet run",
-            "preLaunchTask": "Install JandaBox",
+            "windows": {
+                "preLaunchTask": "install_windows",
+            },
+            "linux": {
+                "preLaunchTask": "install_linux",
+            },
         },
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,6 +47,20 @@
             },
         },
         {
+            "name": "Try ServiceBox",
+            "type": "node-terminal",            
+            "request": "launch",
+            "cwd": "/tmp",
+            "command": "rm -rf MyConsole;dotnet new consoleprj --linux -n MyConsole;cd MyConsole;dotnet new servicebox -n MyService --nameSpace Krowa; dotnet run",
+            "windows": {
+                "preLaunchTask": "install_windows",
+            },
+            "linux": {
+                "preLaunchTask": "install_linux",
+            },
+        },
+
+        {
             "name": "Try ConsoleBox Project",
             "type": "node-terminal",            
             "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,8 +14,8 @@
         {
             "label": "install_windows",
             "type": "shell",
-            "command": "powershell",
-            "args": ["-ExecutionPolicy", "Bypass", "-File", ".\\.pack1.ps1"],
+            "command": ".\\.pack.ps1",
+            "args": [""],
             "presentation": {
                 "reveal": "always",
                 "panel": "shared"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Install JandaBox",
+            "label": "install_linux",
             "type": "shell",
             "command": "chmod +x ./.pack.sh && ./.pack.sh",
             "presentation": {
@@ -12,7 +12,18 @@
             "problemMatcher": []
         },
         {
-            "label": "Uninstall JandaBox",
+            "label": "install_windows",
+            "type": "shell",
+            "command": "powershell",
+            "args": ["-ExecutionPolicy", "Bypass", "-File", ".\\.pack1.ps1"],
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "uninstall_jandabox",
             "type": "shell",
             "command": "dotnet new uninstall JandaBox",
             "presentation": {

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Out of the box .NET8 templates
 - Service files: a service interface, an implementation, and an extension class.
 
 ```
-Template Name                            Short Name  Language  Tags
+Template Name                            Short Name  Language  Tags            
 ---------------------------------------  ----------  --------  ----------------
-JandaBox ASP.NET Core Web API            webapibox   [C#]      JandaBox/WebApi
+JandaBox ASP.NET Core Web API            webapibox   [C#]      JandaBox/WebApi 
+JandaBox ASP.NET Core Web API Project    webapiprj   [C#]      JandaBox/WebApi 
 JandaBox Console App                     consolebox  [C#]      JandaBox/Console
-JandaBox NuGet Class Library             nugetbox    [C#]      JandaBox/NuGet
+JandaBox Console App Project             consoleprj  [C#]      JandaBox/Console
+JandaBox NuGet Class Library             nugetbox    [C#]      JandaBox/NuGet  
 JandaBox Service Classes and Extensions  servicebox  [C#]      JandaBox/Service
 ```
-
 
 
 Learn more about templates in the [wiki pages](https://github.com/Jandini/JandaBox/wiki).
@@ -54,6 +55,16 @@ HelloWorld basic console app using command line interface
 ![jandabox](https://user-images.githubusercontent.com/19593367/234421169-106edabc-6288-4498-b6f0-252e8e96f62f.gif)
 
 
+### Console Application Project
+
+Create .NET8 console application project with dependency injection, Serilog and configuration. 
+
+```sh
+dotnet new consoleprj -n HelloWorld
+```
+
+This is project only, without solution files etc. 
+
 
 ### Web API
 
@@ -62,6 +73,18 @@ Create .NET8 web API from `webapibox` template.
 ```sh
 dotnet new webapibox -n MyWebService
 ```
+
+The template provides solution file and the API project.
+
+### Web API Project
+
+Create .NET8 web API project only from `webapiprj` template.
+
+```sh
+dotnet new webapiprj -n MyWebService
+```
+
+This template provides project folder only.
 
 
 ### Service Files


### PR DESCRIPTION
Resolves #66 

- [x] Add try servicebox to launch json file (5fb3d15)
- [x] Update README.md file (2857ba4)
- [x] Call script directly becaues default shell is powershell under windows (a5da489)
- [x] Add platform dependent pre launch tasks (bbe40d8)